### PR TITLE
Celestia Contributing doc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+
+# Everything goes through the following "global owners" by default.
+# Unless a later match takes precedence, these three will be
+# requested for review when someone opens a PR.
+# Note that the last matching pattern takes precedence, so
+# global owners are only requested if there isn't a more specific
+# codeowner specified below. For this reason, the global codeowners
+# are often repeated in package-level definitions.
+* @liamsi @MSevey
+

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -68,6 +68,7 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     if: ${{ (needs.changes.outputs.updates == 'true' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch' }}
+    permissions: "write-all"
     steps:
       - uses: actions/checkout@v3
       - name: Version Release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,20 @@ request (i.e. adding labels). Teams are given write access to the repositories
 that they are responsible for working on. For example, the `celestia-node` team
 would have write access to the `celestia-node` repository.
 
+### Codeowners
+
+All production repos must use Codeowners. Codeowners are typically the team
+leads and/or engineering leadership members. 
+
 ### .github
 
 Celestia utilizes the organization's `.github` repository. This repository is
 used to store common organization level content like Github actions, issue
 templates, PR templates, etc.
+
+### Repository Settings
+
+...
 
 ## Development
 
@@ -37,7 +46,23 @@ in order to submit a PR. If you have write access to a repository, because you
 are a member of that sub team, then you can push your development branches
 directly to the repository.
 
+### ADRs
+
+For architectural changes or improvements, Celestia uses Architecture Decision
+Record (ADRs) to flush out the design scope. These live in the code under
+`docs/adr`. PRs are used to open new ADRs for approval. 
+
+### Issues
+
+When proposing new work, an issue should be created. Issues can be created for
+bugs, feature requests, improvements based on ADRs, etc.
+
 ### Pull Requests
+
+Before opening a PR, make sure that the scope of work was previously
+communicated, either via an ADR or an issue. Submitting code that has no
+background context is likely to be rejected because the implication and design
+has not been properly discussed.
 
 Celestia has a culture of prioritizing PRs. This prioritization focuses on
 unblocking others and finishing work before starting new work. 
@@ -63,8 +88,4 @@ All repos have the following branch protections requirements:
 - Status checks must be passing
 - Conversations must be resolved
 
-### Codeowners
-
-All production repos must use Codeowners. Codeowners are typically the team
-leads and/or engineering leadership members. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Record (ADRs) to flush out the design scope. These live in the code under
 When proposing new work, an issue should be created. Issues can be created for
 bugs, feature requests, improvements based on ADRs, etc. Issue templates should
 be used whenever possible, but especially for bug reports, feature requests, and
-ADRs to ensure all the necessary information is captured. 
+ADRs to ensure all the necessary information is captured.
 
 ### Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing to Celestia
 
 Welcome and thank you for contributing to building Celestia, the first modular
-blockchain network. 
+blockchain network.
 
-In this guide, you will find information about how Celestia manages the
-`CelestiaOrg` Github as well as expectations around our engineering standards.
+In this guide, you will find information about how the Celestia team manages the
+`celestiaorg` Github as well as expectations around our engineering standards.
 
 ## Github Management
 
@@ -12,12 +12,12 @@ The `celestiaorg` Github uses teams to manage access to the organization and
 its repositories. Members of the Celestia core team and key contributors are
 added to the Github team that aligns with the scope of work they perform. For
 example, those working on the `celestia-node` repository are added to the
-`celestia-node` team. 
+`celestia-node` team.
 
 ### Permissions
 
-By default, all teams have Triage access to all repositories in the
-`CelestiaOrg` Github. This allows for anyone to help manage issues and pull
+By default, all teams have `Triage` access to all repositories in the
+`celestiaorg` Github. This allows for anyone to help manage issues and pull
 requests (i.e. adding labels). Teams are given write access to the repositories
 that they are responsible for working on. For example, the `celestia-node` team
 would have write access to the `celestia-node` repository.
@@ -25,17 +25,34 @@ would have write access to the `celestia-node` repository.
 ### Codeowners
 
 All production repos must use Codeowners. Codeowners are typically the team
-leads and/or engineering leadership members. 
+leads and/or engineering leadership members.
 
 ### .github
 
-Celestia utilizes the organization's `.github` repository. This repository is
-used to store common organization level content like Github actions, issue
-templates, PR templates, etc.
+The Celestia team utilizes the organization's `.github` repository. This
+repository is used to store common organization level content like Github
+actions, issue templates, PR templates, etc.
 
 ### Repository Settings
 
-...
+The following is a list of key settings that should be enabled on all production
+repositories:
+
+**Enabled:**
+
+- Issues
+- Projects
+- Perserve this repository
+- Allow squash merging
+  - Default to pull request title
+- Always suggest updating pull request branches
+- Allow auto-merge
+- Automatically delete head branches
+
+**Disabled:**
+
+- Allow merge commits
+- Allow rebase merging
 
 ## Development
 
@@ -50,7 +67,7 @@ directly to the repository.
 
 For architectural changes or improvements, Celestia uses Architecture Decision
 Record (ADRs) to flush out the design scope. These live in the code under
-`docs/adr`. PRs are used to open new ADRs for approval. 
+`docs/adr`. PRs are used to open new ADRs for approval.
 
 ### Issues
 
@@ -64,8 +81,8 @@ communicated, either via an ADR or an issue. Submitting code that has no
 background context is likely to be rejected because the implication and design
 has not been properly discussed.
 
-Celestia has a culture of prioritizing PRs. This prioritization focuses on
-unblocking others and finishing work before starting new work. 
+The Celestia team has a culture of prioritizing PRs. This prioritization focuses
+on unblocking others and finishing existing work before starting new work.
 
 As a developer, you are responsible for ensuring your code gets merged. This
 means you should be verifying that the appropriate reviewers are assigned and
@@ -81,11 +98,10 @@ and statements should be avoided. Being clear when a comment is a blocking chang
 okay to be a follow up, or just a personal preference enables developers to
 effectively implement the feedback on a PR.  
 
-All repos have the following branch protections requirements:
+All production repos have the following branch protections requirements:
+
 - 2 approvals
 - Codeowner approval
 - New commits dismiss approvals
 - Status checks must be passing
 - Conversations must be resolved
-
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,14 @@ Celestia utilizes the organization's `.github` repository. This repository is
 used to store common organization level content like Github actions, issue
 templates, PR templates, etc.
 
-## Development 
+## Development
+
+### What the Fork
+
+The default development flow is to fork the repository that you are working on
+in order to submit a PR. If you have write access to a repository, because you
+are a member of that sub team, then you can push your development branches
+directly to the repository.
 
 ### Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ repositories:
 - Issues
 - Projects
 - Perserve this repository
+- Allow merge commits **Forked Repos Only**
 - Allow squash merging
   - Default to pull request title
 - Always suggest updating pull request branches
@@ -51,7 +52,7 @@ repositories:
 
 **Disabled:**
 
-- Allow merge commits
+- Allow merge commits **Except Forked Repos**
 - Allow rebase merging
 
 ## Development
@@ -72,7 +73,9 @@ Record (ADRs) to flush out the design scope. These live in the code under
 ### Issues
 
 When proposing new work, an issue should be created. Issues can be created for
-bugs, feature requests, improvements based on ADRs, etc.
+bugs, feature requests, improvements based on ADRs, etc. Issue templates should
+be used whenever possible, but especially for bug reports, feature requests, and
+ADRs to ensure all the necessary information is captured. 
 
 ### Pull Requests
 
@@ -81,13 +84,14 @@ communicated, either via an ADR or an issue. Submitting code that has no
 background context is likely to be rejected because the implication and design
 has not been properly discussed.
 
-The Celestia team has a culture of prioritizing PRs. This prioritization focuses
-on unblocking others and finishing existing work before starting new work.
+The Celestia team has a culture of prioritizing the review of PRs. This
+prioritization focuses on unblocking others and finishing existing work before
+starting new work.
 
 As a developer, you are responsible for ensuring your code gets merged. This
 means you should be verifying that the appropriate reviewers are assigned and
 that you are responding to review comments promptly. When given the choice to
-start a new PR or work on closing out an existing PR, you should always choose
+start a new PR or work on closing out an existing PR, you should usually choose
 closing out the existing PR.
 
 As a reviewer, it is your responsibility to be providing prompt, action oriented

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to Celestia
+
+Welcome and Thank You for contributing to building Celestia, the first modular
+blockchain network. 
+
+In this guide you will find information about how Celestia manages the
+`CelestiaOrg` Github as well as expectation around our Engineering Standards.
+
+## Github Management
+
+The `CelestiaOrg` Github uses teams to manage access to the organization and
+its repositories. Members of the Celestia core team and key contributors are
+added to the Github team that aligns with the scope of work they perform. For
+example, those working on the `celestia-node` repository are added to the
+`celestia-node` team. 
+
+### Permissions
+
+By default, all teams have Triage access to all repositories in the
+`CelestiaOrg` Github. This allows for anyone to help manage issues and pull
+request (i.e. adding labels). Teams are given write access to the repositories
+that they are responsible for working on. For example, the `celestia-node` team
+would have write access to the `celestia-node` repository.
+
+### .github
+
+Celestia utilizes the organization's `.github` repository. This repository is
+used to store common organization level content like Github actions, issue
+templates, PR templates, etc.
+
+## Development 
+
+### Pull Requests
+
+Celestia has a culture of prioritizing PRs. This prioritization focuses on
+unblocking others and finishing work before starting new work. 
+
+As a developer, you are responsible for ensuring your code gets merged. This
+means you should be verifying that the appropriate reviewers are assigned and
+that you are responding to review comments promptly. When given the choice to
+start a new PR or work on closing out an existing PR, you should always choose
+closing out the existing PR.
+
+As a reviewer, it is your responsibility to be providing prompt, action oriented
+reviews. Clearing out your requests reviews should be a daily activity. Action
+oriented reviews means that there is a clear action step for the developer of
+the PR to take in order to get the PR approved and merged. Open ended questions
+and statements so be avoided. Being clear when a comment is a blocking change,
+okay to be a follow up, or just a personal preference enables developers to
+effectively implement the feedback on a PR.  
+
+All repos have the following branch protections requirements:
+- 2 approvals
+- Codeowner approval
+- New commits dismiss approvals
+- Status checks must be passing
+- Conversations must be resolved
+
+### Codeowners
+
+All production repos must use Codeowners. Codeowners are typically the team
+leads and/or engineering leadership members. 
+


### PR DESCRIPTION
This PR creates an org level `CONTRIBUTING.md` doc. 

If there is no `CONTRIBUTING.md` doc in a repository, this one will be used.  

This is an initial draft that focuses on some key parts of our Github processes. In the future this doc can be expanded to contain more information around our engineering standards. 