### PR TITLE
.github: add markdown-lint action and remove scheduled run

### DIFF
--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -1,0 +1,17 @@
+name: "Markdown Lint"
+description: "Lint markdown files with markdownlint"
+inputs:
+  config_file_path:
+    required: false
+    description: "relative path to a .markdownlint.yaml config file"
+    default: ".markdownlint.yaml"
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - run: npm install -g markdownlint-cli@0.32.1
+      shell: bash
+    - run: markdownlint --config {{ inputs.config_file_path }} **/*.md
+      shell: bash

--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -13,5 +13,5 @@ runs:
         node-version: 18
     - run: npm install -g markdownlint-cli@0.32.1
       shell: bash
-    - run: markdownlint --config "{{ inputs.config_file_path }}" **/*.md
+    - run: markdownlint --config ${{ inputs.config_file_path }} **/*.md
       shell: bash

--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -13,5 +13,5 @@ runs:
         node-version: 18
     - run: npm install -g markdownlint-cli@0.32.1
       shell: bash
-    - run: markdownlint --config {{ inputs.config_file_path }} **/*.md
+    - run: markdownlint --config "{{ inputs.config_file_path }}" **/*.md
       shell: bash

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -1,7 +1,6 @@
 # This workflow is an example of a combination of automatic and manual release.
 # The triggers are:
 #   - Push
-#   - Schedule
 #   - Workflow Dispatch
 #
 # This workflow uses the `if` conditions to control when the CI runs versus when
@@ -10,9 +9,6 @@
 # The CI runs when pull requests are created and also when code is merged into
 # main, i.e. push events to main.
 #
-# It will run nightly at 1:15am, on those nightly runs, if there have been
-# changes since the last release, it will also auto bump the patch release.
-#
 # Lastly, it will trigger from manually workflow dispatches.
 name: CI and Release
 on:
@@ -20,9 +16,6 @@ on:
     branches:
       - main
   pull_request:
-  schedule:
-    # Run daily at 1:15am
-    - cron: "15 1 * * *"
   workflow_dispatch:
     # Inputs the workflow accepts.
     inputs:
@@ -48,26 +41,19 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/yamllint
 
-  # Check if there were any changes since the last tag if this is a scheduled event
-  changes:
-    needs: [yamllint]
+  markdown-lint:
     runs-on: ubuntu-latest
-    outputs:
-      updates: ${{steps.changes.outputs.any == 'true'}}
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # Required due to the weg Git works, without it this action won't be able to find any or the correct tags
-      - uses: ./.github/actions/changes-since-last-tag
+      - uses: ./.github/actions/markdown-lint
 
   # Make a release if
   # - there were changes and this is a scheduled job
   # - This is a manually trigger job, i.e. workflow_dispatch
   release:
-    needs: changes
+    needs: [yamllint, markdown-lint]
     runs-on: ubuntu-latest
-    if: ${{ (needs.changes.outputs.updates == 'true' && github.event_name == 'schedule') || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     permissions: "write-all"
     steps:
       - uses: actions/checkout@v3

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,3 @@
+"default": true # Default state for all rules
+"MD013": false # Disable rule for line length
+"MD033": false # Disable rule banning inline HTML

--- a/EXAMPLE_pull_request_template.md
+++ b/EXAMPLE_pull_request_template.md
@@ -9,10 +9,12 @@ Screen shots and/or asciinema recordings are very helpful.
 -->
 
 ## Checklist
+
 Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
- - [ ] All new methods or updated methods have clear docstrings
- - [ ] Testing added or updated for new methods
- - [ ] Approriate documentation updated
+
+- [ ] All new methods or updated methods have clear docstrings
+- [ ] Testing added or updated for new methods
+- [ ] Approriate documentation updated
 
 ## Issues Closed
 <!--

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-This repository can be used for common Celestia Organization information, such as Issue Template, PR Templates, Contributor guide, and Github Actions and Workflows.
+# .github
+
+This repository can be used for common Celestia Organization information, such
+as Issue Template, PR Templates, Contributor guide, and Github Actions and
+Workflows.


### PR DESCRIPTION
This PR refactors the markdown-lint action into this repo and integrates it with this repo's CI. 

Now all other repos can use the same action.