### PR TITLE
.github: update markdown-lint action to include link checker and add stale workflow

### DIFF
--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -7,7 +7,11 @@ inputs:
     default: ".markdownlint.yaml"
   folder_path:
     required: false
-    description: "Specific folder to link"
+    description: >
+      By default the github-action-markdown-link-check action checks for all
+      markdown files in this repo. Use this option to limit checks to only
+      specific folders. Use comma separated values for checking multiple
+      folders.
     default: "."
 
 runs:

--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -5,6 +5,11 @@ inputs:
     required: false
     description: "relative path to a .markdownlint.yaml config file"
     default: ".markdownlint.yaml"
+  folder_path:
+    required: false
+    description: "Specific folder to link"
+    default: "."
+
 runs:
   using: "composite"
   steps:
@@ -15,3 +20,6 @@ runs:
       shell: bash
     - run: markdownlint --config ${{ inputs.config_file_path }} **/*.md
       shell: bash
+    - uses: gaurav-nelson/github-action-markdown-link-check@1.0.14
+      with:
+        folder-path: ${{ inputs.folder_path }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,7 +1,7 @@
 name: Daily
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 1 * * *" # every day at 1 AM
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,11 @@
+name: Daily
+on:
+  schedule:
+    - 0 0 * * *
+  workflow_dispatch:
+
+jobs:
+  stale-PRs:
+    uses: ./.github/workflows/reusable_stale.yml@main
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -6,6 +6,5 @@ on:
 
 jobs:
   stale-PRs:
-    uses: ./.github/workflows/reusable_stale.yml@main
-    with:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/reusable_stale.yml
+    secrets: inherit

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,7 +1,7 @@
 name: Daily
 on:
   schedule:
-    - 0 0 * * *
+    - cron: "0 1 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/reusable_stale.yml
+++ b/.github/workflows/reusable_stale.yml
@@ -1,0 +1,37 @@
+name: "Close stale issues & pull requests"
+on:
+  workflow_call:
+    inputs:
+      github-token:
+        required: true
+        type: string
+        description: "the repo's secrets.GITHUB_TOKEN"
+      days-before-close:
+        required: false
+        type: number
+        default: 7
+        description: "How long before a stale PR is closed (default 7 days)"
+      days-before-stale:
+        required: false
+        type: number
+        default: 30
+        description: "How long before a PR is marked as stale (default 30 days)"
+      exempt-pr-labels:
+        required: false
+        type: string
+        description: "Comma separated list of labels to ignore"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          repo-token: ${{ inputs.github-token }}
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had recent activity. It will be closed if no further
+            activity occurs. Thank you for your contributions.
+          days-before-stale: ${{ inputs.days-before-stale }}
+          days-before-close: ${{ inputs.days-before-close }}
+          exempt-pr-labels: ${{ inputs.exempt-pr-labels }}

--- a/.github/workflows/reusable_stale.yml
+++ b/.github/workflows/reusable_stale.yml
@@ -2,10 +2,6 @@ name: "Close stale issues & pull requests"
 on:
   workflow_call:
     inputs:
-      github-token:
-        required: true
-        type: string
-        description: "the repo's secrets.GITHUB_TOKEN"
       days-before-close:
         required: false
         type: number
@@ -27,7 +23,7 @@ jobs:
     steps:
       - uses: actions/stale@v6
         with:
-          repo-token: ${{ inputs.github-token }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-pr-message: >
             This pull request has been automatically marked as stale because it
             has not had recent activity. It will be closed if no further


### PR DESCRIPTION
This PR extends the `markdown-lint` action to include a link checker that the app was using.

It also brings in the stale PR checking action the app was using and adds a daily workflow to this repo that calls it as an example to other repos. 