### PR TITLE
fix: undo matrix

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -90,9 +90,6 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
   docker-build:
-    strategy:
-      matrix:
-        platforms: ["linux/amd64", "linux/arm64"]
     runs-on: "ubuntu-latest"
     # wait until the jobs are finished.
     needs: ["prepare-env", "docker-security"]
@@ -145,7 +142,7 @@ jobs:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
           OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
         with:
-          platforms: ${{ matrix.platforms }}
+          platforms: linux/amd64,linux/arm64
           # yamllint disable
           # The following line, is execute as an if statement, only push when
           # the branch is main, master or starts with v*


### PR DESCRIPTION
Bug report: https://github.com/celestiaorg/devops/issues/172

Hello!

There's an issue when building the containers using the matrix, it overrides the previous image in the registry... so we cannot use this approach.

Reverts https://github.com/celestiaorg/.github/pull/43


Thanks in advance!

closes: https://github.com/celestiaorg/devops/issues/172