### PR TITLE
feat: TestGround GA

### DIFF
--- a/.github/workflows/reusable_testground_test.yaml
+++ b/.github/workflows/reusable_testground_test.yaml
@@ -37,7 +37,7 @@ env:
   TESTGROUND_URL: ${{ inputs.testground_url }}
   TESTGROUND_REGION: ${{ inputs.testground_region }}
   TEST_FILES_PATH: ${{ inputs.tests_files_path }}
- 
+
 jobs:
   testground:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable_testground_test.yaml
+++ b/.github/workflows/reusable_testground_test.yaml
@@ -21,12 +21,17 @@ on:
         required: false
         type: string
         description: "You can specify any commit that you want to use in the celestia-node repository"
+      celestia_app_commit_sha:
+        required: false
+        type: string
+        description: "You can specify any commit that you want to use in the celestia-app repository"
 
 env:
   REPO_TG: https://github.com/testground/testground.git
   REPO_TEST_TG: https://github.com/celestiaorg/test-infra.git
   ORG: celestiaorg
   CELESTIA_NODE_REPO: celestia-node
+  CELESTIA_APP_REPO: celestia-app
   BRANCH: main
   TG_USER: ga-bot
   TESTGROUND_URL: ${{ inputs.testground_url }}
@@ -65,19 +70,33 @@ jobs:
 
       # In the next step, we can verify if we need to use an specific commit 
       # or we can use the one in the file.
-      - name: Update go.mod with the latest Celestia Node commit
+      - name: Update go.mod with the given inputs
         run: |
-          COMMIT_SHA=$(echo '${{ inputs.celestia_node_commit_sha }}'| tr -d '"')
-          if [[ -z "$COMMIT_SHA" ]];then
+          NODE_COMMIT_SHA=$(echo '${{ inputs.celestia_node_commit_sha }}'| tr -d '"')
+          if [[ -z "$NODE_COMMIT_SHA" ]];then
             echo "[INFO] There's no commit secified, so use the current version"
           else
-            echo "[INFO] Let's use an specific commit SHA"
+            echo "[INFO] Let's use an specific commit SHA for celestia-node"
             cd test-infra
             # Get the latest commit SHA in the celestia-node repo
             CELESTIA_NODE=$(curl -Ls https://api.github.com/repos/${ORG}/${CELESTIA_NODE_REPO}/commits/${BRANCH} | jq -c '.sha'| tr -d '"'| cut -c1-7)
             echo $CELESTIA_NODE
             # Replace the value in the go.mod file
             sed -i "s|github.com/${ORG}/${CELESTIA_NODE_REPO}.*|github.com/${ORG}${CELESTIA_NODE_REPO} ${CELESTIA_NODE}|g" go.mod
+            cd ..
+          fi
+          APP_COMMIT_SHA=$(echo '${{ inputs.celestia_app_commit_sha }}'| tr -d '"')
+          if [[ -z "$APP_COMMIT_SHA" ]];then
+            echo "[INFO] There's no commit secified, so use the current version"
+          else
+            echo "[INFO] Let's use an specific commit SHA for celestia-app"
+            cd test-infra
+            # Get the latest commit SHA in the celestia-node repo
+            CELESTIA_APP=$(curl -Ls https://api.github.com/repos/${ORG}/${CELESTIA_APP_REPO}/commits/${BRANCH} | jq -c '.sha'| tr -d '"'| cut -c1-7)
+            echo $CELESTIA_APP
+            # Replace the value in the go.mod file
+            sed -i "s|github.com/${ORG}/${CELESTIA_APP_REPO}.*|github.com/${ORG}${CELESTIA_APP_REPO} ${CELESTIA_APP}|g" go.mod
+            cd ..
           fi
 
       - name: Plan the execution
@@ -92,15 +111,19 @@ jobs:
           cd test-infra
           $GOBIN/testground plan import --from . --name celestia
           $GOBIN/testground daemon &
-          # Let's give some seconds to the daemon service to start
-          sleep 3
+          # Check if TestGround Daemon is listening...
+          until nc -z 127.0.0.1 8042;do
+            sleep 1
+            echo "[INFO] Waiting for the TestGround Daemon to be up & running..."
+          done
+          echo "[INFO] TestGround Daemon is ready to start receiving requests!"
 
       - name: Execute the test
         run: |
           export GOBIN=$(go env GOPATH)/bin
           cd test-infra
           echo "-----------------------------------------"
-          $GOBIN/testground run composition -f ${{ env.TEST_FILES_PATH }} | tee tg_run.log
+          $GOBIN/testground run composition -f ${{ env.TEST_FILES_PATH }} | tee tg_run.log
           echo "-----------------------------------------"
           cat tg_run.log
           echo "-----------------------------------------"

--- a/.github/workflows/reusable_testground_test.yaml
+++ b/.github/workflows/reusable_testground_test.yaml
@@ -68,7 +68,7 @@ jobs:
           EOF
           cat ~/.config/testground/.env.toml
 
-      # In the next step, we can verify if we need to use an specific commit 
+      # In the next step, we can verify if we need to use an specific commit
       # or we can use the one in the file.
       - name: Update go.mod with the given inputs
         run: |

--- a/.github/workflows/reusable_testground_test.yaml
+++ b/.github/workflows/reusable_testground_test.yaml
@@ -1,0 +1,101 @@
+name: TestGround Tests
+
+on:
+  workflow_call:
+    inputs:
+      tests_files_path:
+        description: "Path to Tests"
+        required: true
+        type: string
+        default: "compositions/cluster-k8s/sanity/002-da-sync-8.toml"
+      testground_url:
+        required: true
+        type: string
+        description: "TestGround LoadBalancer URL"
+      testground_region:
+        required: true
+        type: string
+        description: "TestGround Cluster Region"
+        default: "eu-west-1"
+
+env:
+  REPO_TG: https://github.com/testground/testground.git
+  REPO_TEST_TG: https://github.com/celestiaorg/test-infra.git
+  ORG: celestiaorg
+  CELESTIA_NODE_REPO: celestia-node
+  BRANCH: main
+  TG_USER: ga-bot
+  TESTGROUND_URL: ${{ inputs.testground_url }}
+  TESTGROUND_REGION: ${{ inputs.testground_region }}
+  TEST_FILES_PATH: ${{ inputs.tests_files_path }}
+ 
+jobs:
+  testground:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Clone the repo
+        run: |
+          git clone ${{ env.REPO_TG }}
+          git clone ${{ env.REPO_TEST_TG }}
+
+      - name: Build TestGround
+        run: |
+          export GOBIN=$(go env GOPATH)/bin
+          mkdir -p $GOBIN
+          cd testground
+          make goinstall
+
+      - name: Generate Config TestGround
+        run: |
+          mkdir -p ~/.config/testground/
+          cat <<EOF > ~/.config/testground/.env.toml
+          [aws]
+          region="${{ env.TESTGROUND_REGION }}"
+          [client]
+          endpoint = "${{ env.TESTGROUND_URL }}"
+          user="${{ env.TG_USER }}"
+          EOF
+          cat ~/.config/testground/.env.toml
+
+      - name: Update go.mod with the latest Celestia Node commit
+        run: |
+          cd test-infra
+          # Get the latest commit SHA in the celestia-node repo
+          CELESTIA_NODE=$(curl -Ls https://api.github.com/repos/${ORG}/${CELESTIA_NODE_REPO}/commits/${BRANCH} | jq -c '.sha'| tr -d '"'| cut -c1-7)
+          echo $CELESTIA_NODE
+          # Replace the value in the go.mod file
+          sed -i "s|github.com/${ORG}/${CELESTIA_NODE_REPO}.*|github.com/${ORG}${CELESTIA_NODE_REPO} ${CELESTIA_NODE}|g" go.mod
+
+      - name: Plan the execution
+        run: |
+          export GOBIN=$(go env GOPATH)/bin
+          cd test-infra
+          $GOBIN/testground plan import --from . --name celestia
+
+      - name: Start the TestGround Daemon
+        run: |
+          export GOBIN=$(go env GOPATH)/bin
+          cd test-infra
+          $GOBIN/testground plan import --from . --name celestia
+          $GOBIN/testground daemon &
+          # Let's give some seconds to the daemon service to start
+          sleep 3
+
+      - name: Execute the test
+        run: |
+          export GOBIN=$(go env GOPATH)/bin
+          cd test-infra
+          echo "-----------------------------------------"
+          $GOBIN/testground run composition -f ${{ env.TEST_FILES_PATH }} | tee tg_run.log
+          echo "-----------------------------------------"
+          cat tg_run.log
+          echo "-----------------------------------------"
+          TGID=$(awk '/run is queued with ID/ {print $10}' <tg_run.log)
+          # Check that the task was queued
+          if [ -z "$TGID" ];then
+          	echo "[ERROR] TestGround test not queued... something went wrong..."
+          	exit 1
+          fi
+          echo "TestGround ID is: [$TGID]"

--- a/.github/workflows/reusable_testground_test.yaml
+++ b/.github/workflows/reusable_testground_test.yaml
@@ -17,6 +17,10 @@ on:
         type: string
         description: "TestGround Cluster Region"
         default: "eu-west-1"
+      celestia_node_commit_sha:
+        required: false
+        type: string
+        description: "You can specify any commit that you want to use in the celestia-node repository"
 
 env:
   REPO_TG: https://github.com/testground/testground.git
@@ -52,21 +56,29 @@ jobs:
           mkdir -p ~/.config/testground/
           cat <<EOF > ~/.config/testground/.env.toml
           [aws]
-          region="${{ env.TESTGROUND_REGION }}"
+          region="${{ env.TESTGROUND_REGION }}"
           [client]
-          endpoint = "${{ env.TESTGROUND_URL }}"
-          user="${{ env.TG_USER }}"
+          endpoint = "${{ env.TESTGROUND_URL }}"
+          user="${{ env.TG_USER }}"
           EOF
           cat ~/.config/testground/.env.toml
 
+      # In the next step, we can verify if we need to use an specific commit 
+      # or we can use the one in the file.
       - name: Update go.mod with the latest Celestia Node commit
         run: |
-          cd test-infra
-          # Get the latest commit SHA in the celestia-node repo
-          CELESTIA_NODE=$(curl -Ls https://api.github.com/repos/${ORG}/${CELESTIA_NODE_REPO}/commits/${BRANCH} | jq -c '.sha'| tr -d '"'| cut -c1-7)
-          echo $CELESTIA_NODE
-          # Replace the value in the go.mod file
-          sed -i "s|github.com/${ORG}/${CELESTIA_NODE_REPO}.*|github.com/${ORG}${CELESTIA_NODE_REPO} ${CELESTIA_NODE}|g" go.mod
+          COMMIT_SHA=$(echo '${{ inputs.celestia_node_commit_sha }}'| tr -d '"')
+          if [[ -z "$COMMIT_SHA" ]];then
+            echo "[INFO] There's no commit secified, so use the current version"
+          else
+            echo "[INFO] Let's use an specific commit SHA"
+            cd test-infra
+            # Get the latest commit SHA in the celestia-node repo
+            CELESTIA_NODE=$(curl -Ls https://api.github.com/repos/${ORG}/${CELESTIA_NODE_REPO}/commits/${BRANCH} | jq -c '.sha'| tr -d '"'| cut -c1-7)
+            echo $CELESTIA_NODE
+            # Replace the value in the go.mod file
+            sed -i "s|github.com/${ORG}/${CELESTIA_NODE_REPO}.*|github.com/${ORG}${CELESTIA_NODE_REPO} ${CELESTIA_NODE}|g" go.mod
+          fi
 
       - name: Plan the execution
         run: |


### PR DESCRIPTION
# Description

hello team!

This GitHub action, named "TestGround Tests", allows you to run tests on the TestGround platform for a specific set of files in your repository.

This PR contains a common pipeline to execute TestGround via Github Action 👀 

---

## It does some actions

- It checks out the code from the repository.
- It clones the TestGround and test-infra repositories.
  - `test-infra`: where we have the tests
  - `testground`: build the testground tool
- It builds TestGround.
- It generates the TestGround configuration file for the specified region and TestGround LoadBalancer URL.
- If a specific commit SHA is provided for the Celestia node repository, it updates the `go.mod` file to use that specific commit instead of the current version.
- It plans the execution of the test.
- It starts the TestGround daemon service.
- It executes the test.
- It retrieves the TestGround ID for the test run in order to verify if we have queued the tasks or not.

---

## The action takes four inputs:

`tests_files_path`: The path to the tests to be executed.
`testground_url`: The TestGround LoadBalancer URL.
`testground_region`: The TestGround cluster region.
`celestia_node_commit_sha (optional)`: A specific commit SHA to be used in the Celestia node repository.

---

## How can we use it?

An example where we specify the commit sha and we run it at midnight automatically

```yaml
name: TestGround Nightly

on:
  schedule:
    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
    - cron: '0 0 * * *' # triggered at midnight

env:
  ORG: celestiaorg
  CELESTIA_NODE_REPO: celestia-node
  BRANCH: main

jobs:
  prepare-env:
    runs-on: ubuntu-latest
    outputs:
      testground_url: ${{ steps.testground_url.outputs.testground_url }}
      testground_region: ${{ steps.testground_region.outputs.testground_region }}
    steps:
      - id: testground_url
        run: echo "testground_url=$(echo ${{ secrets.TESTGROUND_URL }})" >> "$GITHUB_OUTPUT"
      - id: testground_region
        run: echo "testground_region=$(echo ${{ secrets.TESTGROUND_REGION }})" >> "$GITHUB_OUTPUT"

  # We want to specify the latest commit, so we use this job to get it from the
  # repo and use it in the inputs
  celestia-node-latest-commit:
    runs-on: ubuntu-latest
    outputs:
      celestia_node_latest_commit: ${{ steps.celestia_node_latest_commit.outputs.celestia_node_latest_commit }}
    steps:
      - id: celestia_node_latest_commit
        name: Get the latest commit
        run: |
          # Get the latest commit SHA in the celestia-node repo
          CELESTIA_NODE=$(curl -Ls https://api.github.com/repos/${ORG}/${CELESTIA_NODE_REPO}/commits/${BRANCH} | jq -c '.sha'| tr -d '"'| cut -c1-7)
          echo $CELESTIA_NODE
          # Replace the value in the go.mod file
          echo "celestia_node_latest_commit=$(echo $CELESTIA_NODE)" >> "$GITHUB_OUTPUT"

  testground:
    needs: [prepare-env, celestia-node-latest-commit]
     uses: celestiaorg/.github/.github/workflows/reusable_testground_tests.yaml@main # yamllint disable-line rule:line-length
    with:
      tests_files_path: "compositions/cluster-k8s/sanity/002-da-sync-8.toml"
      testground_url: ${{ needs.prepare-env.outputs.testground_url }}"
      testground_region: ${{ needs.prepare-env.outputs.testground_region }}"
      celestia_node_commit_sha: ${{ needs.celestia-node-latest-commit.outputs.celestia_node_latest_commit }}"
```

Another option can be:
This one will be triggered when pushing to `main` branch.
```yaml
name: TestGround Test

on:
  push:
    branches:
      - 'main'

env:
  ORG: celestiaorg
  CELESTIA_NODE_REPO: celestia-node
  BRANCH: main

jobs:
  prepare-env:
    runs-on: ubuntu-latest
    outputs:
      testground_url: ${{ steps.testground_url.outputs.testground_url }}
      testground_region: ${{ steps.testground_region.outputs.testground_region }}
    steps:
      - id: testground_url
        run: echo "testground_url=$(echo ${{ secrets.TESTGROUND_URL }})" >> "$GITHUB_OUTPUT"
      - id: testground_region
        run: echo "testground_region=$(echo ${{ secrets.TESTGROUND_REGION }})" >> "$GITHUB_OUTPUT"

  testground:
    needs: prepare-env
     uses: celestiaorg/.github/.github/workflows/reusable_testground_tests.yaml@main # yamllint disable-line rule:line-length
    with:
      tests_files_path: "compositions/cluster-k8s/sanity/002-da-sync-8.toml"
      testground_url: ${{ needs.prepare-env.outputs.testground_url }}"
      testground_region: ${{ needs.prepare-env.outputs.testground_region }}"
```

---

## Issues

Related to: https://github.com/celestiaorg/test-infra/issues/173

---

Thanks in advance! 🚀 


Jose Ramon Mañes