### PR TITLE
feat: speed up amd64 availability & push amd64 on each commit

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -150,16 +150,16 @@ jobs:
       # `master` branch or a versioned `v*` branch
       - name: Build and Push Docker Image (amd64 and arm64)
         uses: docker/build-push-action@v4
+        # yamllint disable
+        # only run when the branch is main, master or starts with v*
+        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
+        # yamllint enable
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
           OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
         with:
           platforms: linux/amd64,linux/arm64
-          # yamllint disable
-          # The following line, is execute as an if statement, only push when
-          # the branch is main, master or starts with v*
-          push: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
-          # yamllint enable
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -125,7 +125,7 @@ jobs:
           tags: |
             # output minimal (short sha)
             type=raw,value={{sha}}
-            # output v0.2.1/v*-*
+            # output v0.2.1/v*-* (or sha of no tag)
             type=semver,pattern={{raw}}
             # pull request event
             type=ref,enable=true,prefix=pr-,suffix=,event=pr
@@ -134,9 +134,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Build and Push Docker Image (amd64)
+        uses: docker/build-push-action@v4
+        env:
+          OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
+          OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
+        with:
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: ${{ inputs.dockerfile }}
+
       # We always build the image but we only push if we are on the `main`,
       # `master` branch or a versioned `v*` branch
-      - name: Build and PushDocker Image
+      - name: Build and Push Docker Image (amd64 and arm64)
         uses: docker/build-push-action@v4
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}

--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -141,6 +141,7 @@ jobs:
           OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
         with:
           platforms: linux/amd64
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ inputs.dockerfile }}


### PR DESCRIPTION
This PR changes two things:
- Build and push the amd64 container image, once finished build amd64 and arm64 and override previously pushed image
- Push amd64 images on each push (with sha tagged containers)

I tested it here:
- https://github.com/smuu/celestiaorg-celestia-node/actions?query=branch%3Afeature%2Fdecouple-arch-builds
- https://github.com/smuu/celestiaorg-celestia-node/actions?query=branch%3Av9.9.9

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
