### PR TITLE
Remove failing docker publish line

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -134,18 +134,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and Push Docker Image (amd64)
-        uses: docker/build-push-action@v4
-        env:
-          OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
-          OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
-        with:
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          file: ${{ inputs.dockerfile }}
-
       # We always build the image but we only push if we are on the `main`,
       # `master` branch or a versioned `v*` branch
       - name: Build and Push Docker Image (amd64 and arm64)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
The docker workflow had a duplicate build and push step that was causing the CI to fail.

This should be applied/verified on rollkit and we should bump the version. 

This should close https://github.com/celestiaorg/devops/issues/326

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
