### PR TITLE
feat: use context - seems like it fixes the ldflags issue

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -66,6 +66,7 @@ jobs:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
           OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
         with:
+          context: .
           push: false
           platforms: linux/amd64
           # we're building the container before the scan, use the short sha tag
@@ -146,6 +147,7 @@ jobs:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
           OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
hello team!

I've added the property `context` to the pipelines due to the issue that we're facing that we lose the `ldflags` values after building the container using GitHub.

I've done some different tests, and I realized that if we added this property, we would keep the values and won't need to add the `embed` files in the repos.

Some of the containers tested are:
https://github.com/jrmanes/celestia-node/pkgs/container/celestia-node
https://github.com/jrmanes/.github/commits/main/.github/workflows/reusable_dockerfile_pipeline.yml

---

Some images:

## Celestia-node:

Without using `context` during build:

<img width="1346" alt="Screenshot 2023-07-10 at 12 38 53" src="https://github.com/celestiaorg/.github/assets/32740567/567d84b3-4e4f-4802-b00d-350a43427a0a">


Using `context` during build:
<img width="1312" alt="Screenshot 2023-07-10 at 12 51 36" src="https://github.com/celestiaorg/.github/assets/32740567/fba7ca0f-1cfb-47ad-8c74-081753f58169">

---

## Celestia-app:

*It will report only if it's in a tag, it's okay if we cannot see it, only with tags*


---

I hope this will fix the issue that we're facing atm

Thanks in advance!


Jose Ramon Mañes

