### PR TITLE
chore: upgrade to markdownlint-cli v0.35.0

### DIFF
--- a/.github/actions/markdown-lint/action.yml
+++ b/.github/actions/markdown-lint/action.yml
@@ -20,7 +20,7 @@ runs:
     - uses: actions/setup-node@v3
       with:
         node-version: 18
-    - run: npm install -g markdownlint-cli@0.32.1
+    - run: npm install -g markdownlint-cli@0.35.0
       shell: bash
     - run: markdownlint --config ${{ inputs.config_file_path }} **/*.md
       shell: bash


### PR DESCRIPTION
Attempt to resolve https://github.com/celestiaorg/celestia-app/issues/2212 by upgrading markdownlint-cli to the latest release: [v0.35.0](https://github.com/igorshubovych/markdownlint-cli/releases/tag/v0.35.0)

cc: @SweeXordious 