### PR TITLE
bug: fix github.event_name error

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -70,7 +70,7 @@ jobs:
         id: setting_logic
         run: |
           # yamllint disable
-          echo "build_for_pr=${{ github.event == 'pull_request' }}" >> "$GITHUB_OUTPUT"
+          echo "build_for_pr=${{ github.event_name == 'pull_request' }}" >> "$GITHUB_OUTPUT"
           echo "build_for_merge=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}" >> "$GITHUB_OUTPUT"
           echo "not_a_fork=${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}" >> "$GITHUB_OUTPUT"
           # yamllint enable
@@ -84,8 +84,9 @@ jobs:
     steps:
       - name: Log logic
         run: |
-          echo "github.event: ${{ github.event }}"
+          echo "github.event_name: ${{ github.event_name }}"
           echo "github.ref: ${{ github.ref }}"
+          echo "github.event: ${{ toJSON(github.event) }}"
           echo "head repo: ${{ github.event.pull_request.head.repo.full_name }}"
           echo "base repo: ${{ github.event.pull_request.base.repo.full_name }}"
           echo "build_for_pr: ${{ needs.prepare-env.outputs.build_for_pr }}"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
logic was use `github.event` instead of `github.event_name` resulting in `build_for_pr` always being false.
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
