### PR TITLE
fix: fix failing docker CI due to permission issues on PRs

### DIFF
--- a/.github/workflows/dockerfile_workflow_test.yaml
+++ b/.github/workflows/dockerfile_workflow_test.yaml
@@ -3,7 +3,7 @@
 # to build and push the Docker image to the container registries.
 #
 # The reason this workflow targets the develop branch is so that we can test the
-# action in the PR. If we targeted main, we would need to merge changes in
+# action in the PR. If we targeted main, we would need to merge changes into main
 # before being able to test them.
 #
 name: Build Using Reusable Workflow

--- a/.github/workflows/dockerfile_workflow_test.yaml
+++ b/.github/workflows/dockerfile_workflow_test.yaml
@@ -3,7 +3,7 @@
 # to build and push the Docker image to the container registries.
 #
 # The reason this workflow targets the develop branch is so that we can test the
-# action in the PR. If we targeted main, we would need to merge changes into
+# action in the PR. If we targeted main, we would need to merge changes in
 # before being able to test them.
 #
 name: Build Using Reusable Workflow

--- a/.github/workflows/dockerfile_workflow_test.yaml
+++ b/.github/workflows/dockerfile_workflow_test.yaml
@@ -1,6 +1,16 @@
+#
+# This workflow is used to test the `reusable_dockerfile_pipeline` action used
+# to build and push the Docker image to the container registries.
+#
+# The reason this workflow targets the develop branch is so that we can test the
+# action in the PR. If we targeted main, we would need to merge changes into
+# before being able to test them.
+#
 name: Build Using Reusable Workflow
 on: [push, pull_request]
 jobs:
+  # reusable-build tests calling the reusable_dockerfile_pipeline while
+  # providing a custom packageName
   reusable-build:
     permissions:
       contents: write
@@ -10,6 +20,9 @@ jobs:
       dockerfile: docker-action-test/Dockerfile
       packageName: docker-test
     secrets: inherit
+
+  # reusable-build-defaults tests calling the reusable_dockerfile_pipeline with
+  # the defaults
   reusable-build-defaults:
     permissions:
       contents: write

--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -172,7 +172,7 @@ jobs:
           severity: "CRITICAL,HIGH"
 
   docker-build:
-    name: docker-build (${{ matrix.registry.name }}; ${{ matrix.registry.registry-url }}/${{ matrix.registry.registry-owner }}/${{ needs.prepare-env.outputs.output_image_name }}:${{ needs.prepare-env.outputs.output_short_sha }})
+    name: docker-build (${{ matrix.registry.name }}; ${{ matrix.registry.registry-url }}/${{ matrix.registry.registry-owner }}/${{ needs.prepare-env.outputs.output_image_name }})
     runs-on: "ubuntu-latest"
     # wait until the jobs are finished.
     needs: ["prepare-env", "logic-check", "docker-security"]
@@ -181,28 +181,40 @@ jobs:
       packages: write
     strategy:
       matrix:
+        # run-on-pr is used to skip running registries that are expected to fail
+        # due to github permission issues with org wide secrets.
         registry:
           - name: DockerHub
             user-secret: DOCKERHUB_USERNAME
             token-secret: DOCKERHUB_TOKEN
             registry-url: docker.io
             registry-owner: celestiaorg
+            run-on-pr: "false"
           - name: GHCR
             user-secret: ${{ github.repository_owner }}
             token-secret: GITHUB_TOKEN
             registry-url: ghcr.io
             registry-owner: ${{ needs.prepare-env.outputs.repo_owner }}
+            run-on-pr: "true"
           - name: ScaleWay
             user-secret: SCALEWAY_USERNAME
             token-secret: SCW_SECRET_KEY
             registry-url: rg.fr-par.scw.cloud
             registry-owner: celestiaorg
+            run-on-pr: "false"
       fail-fast: false
     steps:
+      - name: Check run conditions
+        id: run_check
+        # We only want to run when the registry is able to run on pr or if it is a merge event
+        run: echo "run=${{ matrix.registry.run-on-pr == needs.prepare-env.outputs.build_for_pr || needs.prepare-env.outputs.build_for_merge == 'true'}}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
+        if: ${{ steps.run_check.outputs.run == 'true'}}
         uses: "actions/checkout@v4"
 
       - name: Login to ${{ matrix.registry.name }}
+        if: ${{ steps.run_check.outputs.run == 'true'}}
         uses: docker/login-action@v3
         with:
           registry: ${{ matrix.registry.registry-url }}
@@ -210,6 +222,7 @@ jobs:
           password: ${{ secrets[matrix.registry.token-secret] }}
 
       - name: Extract Docker Metadata
+        if: ${{ steps.run_check.outputs.run == 'true'}}
         id: meta
         uses: docker/metadata-action@v5
         env:
@@ -233,9 +246,11 @@ jobs:
           # yamllint enable
 
       - name: Set up QEMU
+        if: ${{ steps.run_check.outputs.run == 'true'}}
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        if: ${{ steps.run_check.outputs.run == 'true'}}
         uses: docker/setup-buildx-action@v3
 
       # Build and Publish images on main, master, and versioned branches.
@@ -245,7 +260,7 @@ jobs:
       # the amd64 image since building the arm64 image takes significantly
       # longer.
       - name: "Merge on Main Trigger: Build and Push All Docker Images"
-        if: ${{ needs.prepare-env.outputs.build_for_merge == 'true' }}
+        if: ${{ needs.prepare-env.outputs.build_for_merge == 'true' && steps.run_check.outputs.run == 'true'}}
         uses: docker/build-push-action@v5
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
@@ -265,7 +280,7 @@ jobs:
       # forks can't push, we still want to try and build the image to catch
       # bugs. For testing purposes we only need an amd64 image.
       - name: "Pull Request Trigger: Build and Push amd64 Docker Image"
-        if: ${{ needs.prepare-env.outputs.build_for_pr == 'true' }}
+        if: ${{ needs.prepare-env.outputs.build_for_pr == 'true' && steps.run_check.outputs.run == 'true'}}
         uses: docker/build-push-action@v5
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}

--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -206,7 +206,7 @@ jobs:
     steps:
       - name: Check run conditions
         id: run_check
-        # We only want to run when the registry is able to run on pr or if it is a merge event
+        # We only want to run when the registry is able to run on PR or if it is a merge event
         run: echo "run=${{ matrix.registry.run-on-pr == needs.prepare-env.outputs.build_for_pr || needs.prepare-env.outputs.build_for_merge == 'true'}}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Closes #93 

This change skips running the dockerhub and scaleway runs when it is a PR. 
We use org level secrets for logging into dockerhub and scaleway, and these secretes are only accessible by native branches, or users with write access. 
This means that on PRs from forks or non team members, the runs would fail. 
These still pass on main on merge, because at that point, the permission issue is no longer present. 

Additional this change removes the appended hash to the action run, which causes issues with linking the action to the branch protection rules. 

Verified and tested: https://github.com/celestiaorg/.github/actions/runs/7790602743

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
