### PR TITLE
update: bump setup-python to v5

### DIFF
--- a/.github/actions/yamllint/action.yml
+++ b/.github/actions/yamllint/action.yml
@@ -6,7 +6,7 @@ description: "Lint yaml code with yamllint"
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.x"
         architecture: x64


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Downstream actions are showing a warning on yamllint as it seems setup-python@v4 uses a node version earlier than v20. This little bump should update things enough to bring downstream callers into line with a modern enough node version (ie: not node 16)

<img width="1089" alt="warn" src="https://github.com/celestiaorg/.github/assets/12677/b36f209c-e169-4689-bbfe-bd9c05ff4642">