### PR TITLE
feat: add checkout ref to support building from a specific ref manually

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -17,6 +17,10 @@ on:
         type: string
         description: "The docker context"
         default: "."
+      checkout_ref:
+        required: false
+        type: string
+        description: "Specific checkout reference"
 
 env:
   GITHUB_REG: ghcr.io
@@ -36,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: "actions/checkout@v4"
+        with:
+          ref: ${{ inputs.checkout_ref }}
 
       - name: Add vars to ENV
         id: setting_env
@@ -148,6 +154,8 @@ jobs:
     steps:
       - name: Checkout
         uses: "actions/checkout@v4"
+        with:
+          ref: ${{ inputs.checkout_ref }}
 
       - name: Build
         uses: docker/build-push-action@v5
@@ -227,6 +235,8 @@ jobs:
       - name: Checkout
         if: ${{ steps.run_check.outputs.run == 'true'}}
         uses: "actions/checkout@v4"
+        with:
+          ref: ${{ inputs.checkout_ref }}
 
       - name: Login to ${{ matrix.registry.name }}
         if: ${{ steps.run_check.outputs.run == 'true'}}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Added a `checkout_ref` input to the dockerfile workflow. This would enable the calling repos to add a `workflow_dispatch` trigger and supply a specific ref (tag, branch, sha) to run the workflow against. The default is an empty string which tells the checkout action to use the ref of the calling event. 

REF: https://github.com/actions/checkout?tab=readme-ov-file#usage