### PR TITLE
fix: add type=raw tag for workflow dispatch events to metadata step

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -268,6 +268,8 @@ jobs:
             type=semver,pattern={{raw}}
             # pull request event
             type=ref,enable=true,prefix=pr-,suffix=,event=pr
+            # This if for the workflow dispath events, it is type=raw and should be empty by default 
+            ${{ inputs.checkout_ref }}
           # yamllint enable
 
       - name: Set up QEMU


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
resolves #113 

Example of empty tag on push event confirming no impact: https://github.com/celestiaorg/.github/actions/runs/11035460576/job/30651542020#step:5:15

Example of the tag being present: 
In the step: https://github.com/celestiaorg/.github/actions/runs/11035583857/job/30651974980#step:5:58
In the output: https://github.com/celestiaorg/.github/actions/runs/11035583857/job/30651974980#step:5:16


