### PR TITLE
fix: correctly pass build arguments to docker build, build images on PRs

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -24,8 +24,13 @@ on:
       buildArgs:
         required: false
         type: string
-        description: "Multiline string of build args"
+        description: 'string containing a space separated list build args e.g. "TARGETOS=linux TARGETARCH=amd64"'
         default: ""
+      enableForPRs:
+        required: false
+        type: boolean
+        description: "specify as true if you want to push the image built and pushed from PRs"
+        default: false
 
 env:
   GITHUB_REG: ghcr.io
@@ -279,9 +284,24 @@ jobs:
         if: ${{ steps.run_check.outputs.run == 'true'}}
         uses: docker/setup-buildx-action@v3
 
-      # Build and Publish images on main, master, and versioned branches.
-      - name: "Merge on Main Trigger: Build and Push All Docker Images"
-        if: ${{ needs.prepare-env.outputs.build_for_merge == 'true' && steps.run_check.outputs.run == 'true'}}
+        # the build-push-action.build-args argument expects a newline separated string.
+        # when you pass a string to a re-usable workflow, it is interpreted as a single line.
+        # this step converts that single line into a multi line string so it is correctly interpreted as
+        # build arguments.
+      - name: Convert buildArgs to newline-delimited string
+        if: ${{ inputs.buildArgs }}
+        id: convert_args
+        run: |
+          {
+            echo 'converted<<EOF'
+            echo "${{ inputs.buildArgs }}" | xargs -n1
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      # By defualt, build and Publish images on main, master, and versioned branches.
+      # if enableForPRs is specified, images will be built for PRs also.
+      - name: "Build and Push All Docker Images"
+        if: ${{ (needs.prepare-env.outputs.build_for_merge == 'true' || inputs.enableForPRs ) && steps.run_check.outputs.run == 'true' }}
         uses: docker/build-push-action@v6
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
@@ -294,4 +314,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: ${{ inputs.dockerfile }}
-          build-args: ${{ inputs.buildArgs }}
+          build-args: ${{ steps.convert_args.outputs.converted }}

--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -24,7 +24,7 @@ on:
       buildArgs:
         required: false
         type: string
-        description: 'string containing a space separated list build args e.g. "TARGETOS=linux TARGETARCH=amd64"'
+        description: 'string containing a space separated list build of args e.g. "TARGETOS=linux TARGETARCH=amd64"'
         default: ""
 
 env:

--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -26,11 +26,6 @@ on:
         type: string
         description: 'string containing a space separated list build args e.g. "TARGETOS=linux TARGETARCH=amd64"'
         default: ""
-      enableForPRs:
-        required: false
-        type: boolean
-        description: "specify as true if you want to push the image built and pushed from PRs"
-        default: false
 
 env:
   GITHUB_REG: ghcr.io
@@ -298,10 +293,9 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
-      # By defualt, build and Publish images on main, master, and versioned branches.
-      # if enableForPRs is specified, images will be built for PRs also.
+      # Build and Publish images on main, master, and versioned branches.
       - name: "Build and Push All Docker Images"
-        if: ${{ (needs.prepare-env.outputs.build_for_merge == 'true' || inputs.enableForPRs ) && steps.run_check.outputs.run == 'true' }}
+        if: ${{ steps.run_check.outputs.run == 'true' }}
         uses: docker/build-push-action@v6
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

I went down a bit of a rabbit hole trying to figure out why things weren't working as expected.

There were 2 issues.

1. docker-push-action.build-args expects a multiline string, e.g.

```
TARGETOS=linux
TARGETARCH=amd64
```

however when you pass a string like this to a workflow call, (even if using the correct multi line syntax ) it gets parsed as a single line string.

This PR parses that string and converts it into the correct format. The syntax is a bit weird, but it is what is shown in the [official docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-of-a-multiline-string).

2. The second issue I ran into was that the workflow was not being run on PRs.

there seems to be an issue with the conditional

`if: ${{ needs.prepare-env.outputs.build_for_merge == 'true' && steps.run_check.outputs.run == 'true' }}`

`build_for_merge`  is `false`, but `outputs.run` is `true` due to `build_for_pr` being `true`.

`build_for_merge` is `false` because it is not `main/master/tag` so unless I'm misunderstanding it looks like the logic is a bit.

if my understanding is correct, we can maybe change the conditional around the docker-build-push action to just be
`if: ${{ steps.run_check.outputs.run == 'true' }}` which is what I have done here.

If this is incorrect, happy to change it!

Here is a link to a workflow that successfully passes build arguments using this workflow from my fork https://github.com/01builders/celestia-app/actions/runs/14238566827/job/39902974256?pr=82

the new usage looks like this

```yaml
  docker-multiplexer-build:
    permissions:
      contents: write
      packages: write
    uses: chatton/.github/.github/workflows/reusable_dockerfile_pipeline.yml@ebcec699689ec2e5cd0330e50c770416a9e451b0
    with:
      dockerfile: docker/multiplexer.Dockerfile
      checkout_ref: ${{ github.event.inputs.ref }}
      packageName: celestia-app-multiplexer
      buildArgs: "TARGETOS=linux TARGETARCH=amd64"
    secrets: inherit
```

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
