### PR TITLE
fix: only build and push on merge

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -295,7 +295,7 @@ jobs:
 
       # Build and Publish images on main, master, and versioned branches.
       - name: "Build and Push All Docker Images"
-        if: ${{ steps.run_check.outputs.run == 'true' }}
+        if: ${{ needs.prepare-env.outputs.build_for_merge == 'true' && steps.run_check.outputs.run == 'true' }}
         uses: docker/build-push-action@v6
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/.github/issues/131

We can't push Docker images on PRs from forks. IMO we could skip this entire workflow (not just one step) if this isn't a merge commit but this seems like the easiest way to address the regression.

cc: @chatton 