### PR TITLE
fix: ensure images are built on PRs

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -26,6 +26,11 @@ on:
         type: string
         description: 'string containing a space separated list build of args e.g. "TARGETOS=linux TARGETARCH=amd64"'
         default: ""
+      forceBuild:
+        required: false
+        type: boolean
+        description: "Force docker build and push"
+        default: false
 
 env:
   GITHUB_REG: ghcr.io
@@ -202,7 +207,8 @@ jobs:
     # commits. The logic-check job protects us from the case of both build flags
     # being equal to true.
     if: |
-      needs.prepare-env.outputs.build_for_pr == 'true'
+      inputs.forceBuild
+      || needs.prepare-env.outputs.build_for_pr == 'true'
       || needs.prepare-env.outputs.build_for_merge == 'true'
     permissions:
       contents: write
@@ -229,7 +235,7 @@ jobs:
       - name: Check run conditions
         id: run_check
         # We only want to run when the registry is able to run on PR or if it is a merge event
-        run: echo "run=${{ matrix.registry.run-on-pr == needs.prepare-env.outputs.build_for_pr || needs.prepare-env.outputs.build_for_merge == 'true'}}" >> "$GITHUB_OUTPUT"
+        run: echo "run=${{ inputs.forceBuild || matrix.registry.run-on-pr == needs.prepare-env.outputs.build_for_pr || needs.prepare-env.outputs.build_for_merge == 'true'}}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         if: ${{ steps.run_check.outputs.run == 'true'}}
@@ -295,7 +301,7 @@ jobs:
 
       # Build and Publish images on main, master, and versioned branches.
       - name: "Build and Push All Docker Images"
-        if: ${{ needs.prepare-env.outputs.build_for_merge == 'true' && steps.run_check.outputs.run == 'true' }}
+        if: ${{ inputs.forceBuild || needs.prepare-env.outputs.build_for_merge == 'true' && steps.run_check.outputs.run == 'true' }}
         uses: docker/build-push-action@v6
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}

--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -26,11 +26,6 @@ on:
         type: string
         description: 'string containing a space separated list build of args e.g. "TARGETOS=linux TARGETARCH=amd64"'
         default: ""
-      forceBuild:
-        required: false
-        type: boolean
-        description: "Force docker build and push"
-        default: false
 
 env:
   GITHUB_REG: ghcr.io
@@ -167,10 +162,7 @@ jobs:
     # run if both logic flags are false. This is the case for push events on PR
     # commits. The logic-check job protects us from the case of both build flags
     # being equal to true.
-    if: |
-      inputs.forceBuild
-      || needs.prepare-env.outputs.build_for_pr == 'true'
-      || needs.prepare-env.outputs.build_for_merge == 'true'
+    if: needs.prepare-env.outputs.not_a_fork == 'true'
     permissions:
       contents: write
       packages: write
@@ -196,7 +188,7 @@ jobs:
       - name: Check run conditions
         id: run_check
         # We only want to run when the registry is able to run on PR or if it is a merge event
-        run: echo "run=${{ inputs.forceBuild || matrix.registry.run-on-pr == needs.prepare-env.outputs.build_for_pr || needs.prepare-env.outputs.build_for_merge == 'true'}}" >> "$GITHUB_OUTPUT"
+        run: echo "run=${{ matrix.registry.run-on-pr == needs.prepare-env.outputs.build_for_pr || needs.prepare-env.outputs.build_for_merge == 'true'}}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         if: ${{ steps.run_check.outputs.run == 'true'}}
@@ -251,7 +243,7 @@ jobs:
         # this step converts that single line into a multi line string so it is correctly interpreted as
         # build arguments.
       - name: Convert buildArgs to newline-delimited string
-        if: ${{ inputs.buildArgs }}
+        if: ${{ inputs.buildArgs && steps.run_check.outputs.run == 'true' }}
         id: convert_args
         run: |
           {
@@ -262,13 +254,13 @@ jobs:
 
       # Build and Publish images on main, master, and versioned branches.
       - name: "Build and Push All Docker Images"
-        if: ${{ inputs.forceBuild || needs.prepare-env.outputs.build_for_merge == 'true' && steps.run_check.outputs.run == 'true' }}
+        if: ${{ steps.run_check.outputs.run == 'true'}}
         uses: docker/build-push-action@v6
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
           OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
         with:
-          context: ${{ inputs.dockerContext}}
+          context: ${{ inputs.dockerContext }}
           platforms: linux/arm64,linux/amd64
           provenance: false
           push: true


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

A possible solution to https://github.com/celestiaorg/.github/issues/134

This PR modifies the existing workflow so that the ghcr images are built on PRs. And both dockerhub and ghcr images are built on merge.

Note: I don't think it is possible to purely depend on the `run-on-pr` field, as this would mean you have to hard code in true or false within the strategy matrix and would not be able to dynamically use a conditional (in this case `run`).

As a result of this I left `build_for_pr` and `build_for_merge` unchanged as they provide the correct information needed to determine if we should set `run`.

Tested on my fork https://github.com/chatton/celestia-app/actions/runs/14615820840/job/41003749579 and the images build from PRs.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
