### PR TITLE
fix: retry Set up QEMU on transient Docker Hub rate limits

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -235,9 +235,16 @@ jobs:
             ${{ inputs.checkout_ref }}
           # yamllint enable
 
+      # Wrapped with a retry because Docker Hub sometimes throttles authenticated
+      # pulls of `tonistiigi/binfmt` to the shared `celestiaorg` account, which
+      # fails this step with `toomanyrequests`. Rate-limit errors are transient.
       - name: Set up QEMU
         if: ${{ steps.run_check.outputs.run == 'true'}}
-        uses: docker/setup-qemu-action@v4
+        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea  # v3.8.0
+        with:
+          action: docker/setup-qemu-action@v4
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - name: Set up Docker Buildx
         if: ${{ steps.run_check.outputs.run == 'true'}}


### PR DESCRIPTION
## Summary

- Wrap `docker/setup-qemu-action` with `Wandalen/wretry.action` so that authenticated pulls of `tonistiigi/binfmt` which trip Docker Hub's rolling rate limit on the shared `celestiaorg` account are retried (5 attempts, 30s linear backoff) rather than failing the job.
- Pinned `Wandalen/wretry.action` to a full commit SHA (tag `v3.8.0`).

## Why this step

Across failures observed on downstream repos (e.g. [celestia-app run 24586470810](https://github.com/celestiaorg/celestia-app/actions/runs/24586470810)), all three `DockerHub` matrix jobs failed at `Set up QEMU` with `toomanyrequests ... as '***': dckr_jti_...` — i.e. the authenticated `celestiaorg` account hit its own rate limit. Rate-limit bursts are transient, so a retry clears them.

`Set up Docker Buildx` and `Build and Push All Docker Images` have similar exposure in principle, but wrapping those with `wretry` is complicated by the multiline `tags`/`labels`/`build-args` substitutions (the nested `with:` YAML string breaks on embedded newlines). BuildKit also has internal pull retries. Those are left as follow-ups on #153.

## Test plan

- [ ] CI on this repo passes (yamllint clean on changed lines).
- [ ] Downstream consumer (e.g. celestia-app) picks up `main` SHA and retries succeed on a forced rate-limit scenario.
- [ ] Happy-path unchanged: no timing regression on non-throttled runs (retry only activates on failure).

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)