### PR TITLE
fix: retry docker build-push on transient multi-arch failures + job timeout

### DIFF
--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -161,6 +161,10 @@ jobs:
   docker-build:
     name: docker-build (${{ matrix.registry.name }}; ${{ matrix.registry.registry-url }}/${{ matrix.registry.registry-owner }}/${{ needs.prepare-env.outputs.output_image_name }})
     runs-on: "ubuntu-latest"
+    # Multi-arch builds (linux/arm64 under QEMU emulation) are long-running.
+    # Cap the job so a hung emulated build fails in ~90 min instead of running
+    # to the 6 hour GitHub default.
+    timeout-minutes: 90
     # wait until the jobs are finished.
     needs: ["prepare-env", "logic-check"]
     # We only want to run this step if one of the build flags is true. We don't
@@ -265,8 +269,39 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # Build and Publish images on main, master, and versioned branches.
+      #
+      # The build is wrapped with a single retry: multi-arch builds (linux/arm64
+      # runs under QEMU emulation) are long-running and occasionally fail on
+      # transient errors such as registry pull/push timeouts, `toomanyrequests`
+      # throttling, or emulation hiccups. The retry reuses the buildx layer cache
+      # so it is fast, and re-pushing layers is idempotent. wretry (used for the
+      # QEMU step above) is intentionally not used here: the `tags` and `labels`
+      # inputs are multiline strings, which wretry's `with` map does not forward
+      # correctly.
       - name: "Build and Push All Docker Images"
+        id: build
         if: ${{ steps.run_check.outputs.run == 'true'}}
+        continue-on-error: true
+        uses: docker/build-push-action@v7
+        env:
+          OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
+          OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
+        with:
+          context: ${{ inputs.dockerContext }}
+          platforms: linux/arm64,linux/amd64
+          provenance: false
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          file: ${{ inputs.dockerfile }}
+          build-args: ${{ steps.convert_args.outputs.converted }}
+
+      - name: Wait before retrying the build
+        if: ${{ steps.run_check.outputs.run == 'true' && steps.build.outcome == 'failure' }}
+        run: sleep 30
+
+      - name: "Build and Push All Docker Images (retry)"
+        if: ${{ steps.run_check.outputs.run == 'true' && steps.build.outcome == 'failure' }}
         uses: docker/build-push-action@v7
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}

--- a/.github/workflows/reusable_dockerfile_pipeline.yml
+++ b/.github/workflows/reusable_dockerfile_pipeline.yml
@@ -282,7 +282,7 @@ jobs:
         id: build
         if: ${{ steps.run_check.outputs.run == 'true'}}
         continue-on-error: true
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
           OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}
@@ -302,7 +302,7 @@ jobs:
 
       - name: "Build and Push All Docker Images (retry)"
         if: ${{ steps.run_check.outputs.run == 'true' && steps.build.outcome == 'failure' }}
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         env:
           OUTPUT_SHORT_SHA: ${{ needs.prepare-env.outputs.output_short_sha }}
           OUTPUT_IMAGE_NAME: ${{ needs.prepare-env.outputs.output_image_name }}


### PR DESCRIPTION
## Problem

Multi-arch image builds in this reusable pipeline build `linux/arm64` under **QEMU emulation**, which is slow (observed `go: downloading` taking 240+s) and intermittently fails on transient errors — registry pull/push timeouts, `toomanyrequests` throttling, or emulation hiccups. The `docker/build-push-action` step has **no retry**, so a single transient failure fails the whole publish job, and the job has no `timeout-minutes`, so a hung emulated build runs to the 6-hour default.

This was observed in [`celestiaorg/celestia-app`](https://github.com/celestiaorg/celestia-app) `docker-build-publish` on `main`: ~4 failures over two days, concentrated on the heavy multiplexer image (which pulls v3–v8 base images per architecture), across both registries, with no consistent build error — the signature of transient flakiness. Example failing runs: [26599546875](https://github.com/celestiaorg/celestia-app/actions/runs/26599546875), [26590277430](https://github.com/celestiaorg/celestia-app/actions/runs/26590277430).

## Changes

- **Retry** the `Build and Push All Docker Images` step once: the first attempt runs with `continue-on-error: true`, and a guarded retry step re-runs it (after a 30s delay) only when the first attempt failed. The retry reuses the buildx layer cache so it is fast, and re-pushing layers is idempotent.
  - Note: I deliberately did **not** use `Wandalen/wretry` here (as the QEMU step does) because the `tags` and `labels` inputs are multiline strings produced by `docker/metadata-action`, which wretry's `with` options-map does not forward correctly.
- **`timeout-minutes: 90`** on the `docker-build` job so a hung emulated build fails predictably instead of consuming the 6-hour default.

This complements the recently added QEMU-setup retry (which covers `setup-qemu-action` but not the build/push itself).

## Validation

- `yamllint` (repo config) — exit 0
- `actionlint` — exit 0 (pre-existing shellcheck style warnings on an unrelated script are unchanged)
- The reusable workflow is exercised by this repo's `dockerfile_workflow_test.yaml` in CI.

Tracking: PROTOCO-1820.